### PR TITLE
Update README to fix the version to require

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,8 @@ based PHAR which you may freely reuse.
 Installation
 ============
 
-```json
-require: {
-   "padraic/phar-updater": "~1.0"
-}
+```
+composer require padraic/phar-updater
 ```
 
 The package utilises PHP Streams for remote requests so it will require the openssl

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Installation
 
 ```json
 require: {
-   "padraic/phar-updater": "~1.0@dev"
+   "padraic/phar-updater": "~1.0"
 }
 ```
 


### PR DESCRIPTION
There are stable versions now so it's better to document using them. Also it was confusing, it lead me to believe there was no stable version released yet.