### PR TITLE
Make newVersionAvailable() more flexible

### DIFF
--- a/src/Updater.php
+++ b/src/Updater.php
@@ -319,7 +319,7 @@ class Updater
         $this->newVersion = $this->strategy->getCurrentRemoteVersion($this);
         $this->oldVersion = $this->strategy->getCurrentLocalVersion($this);
 
-        if (!empty($this->newVersion) && ($this->newVersion !== $this->oldVersion)) {
+        if (!empty($this->newVersion) && version_compare($this->newVersion, $this->oldVersion, '>')) {
             return true;
         }
         return false;

--- a/src/Updater.php
+++ b/src/Updater.php
@@ -319,7 +319,10 @@ class Updater
         $this->newVersion = $this->strategy->getCurrentRemoteVersion($this);
         $this->oldVersion = $this->strategy->getCurrentLocalVersion($this);
 
-        if (!empty($this->newVersion) && version_compare($this->newVersion, $this->oldVersion, '>')) {
+        if (!empty($this->newVersion) && $this->newVersion !== $this->oldVersion) {
+            if (!$this->strategy instanceof ShaStrategy && !version_compare($this->newVersion, $this->oldVersion, '>')) {
+                return false;
+            }
             return true;
         }
         return false;


### PR DESCRIPTION
Currently the updater will select the most recent available remote version, provided that it's different from the local version. This PR accounts for the local version being newer than all of the remote versions.